### PR TITLE
Add config edit and save capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,27 @@ your team's channel at a predefined time.
 
 # Usage
 
-Create your configuration file:
+The minimal configuration file has the following format:
+```json
+{
+  "timezone": "America/Montreal",
+  "teams": [
+  ]
+}
+```
+This will allow you to boot the scrumpolice without any teams, which can then be added directly by slack.
+
+Run the bot with a slack bot user token:
+
+```sh
+SCRUMPOLICE_SLACK_TOKEN=xoxb-mytoken scrumpolice -databaseFile db.json
+```
+
+Command-line parameters:
+* **databaseFile**: the path to a file that will be used to save the configuration of the scrumpolice. If the file is not found, the bot will attempt to load the data from file specified in the *config* parameter. Defaults to *db.json*.
+* **config**: the path to a json configuration file that can be used to initialize the permanent config file. It will not be modified by any changes made by users of the bot. Defaults to *config.json*.
+
+Full configuration file syntax:
 
 ```json
 {
@@ -51,12 +71,6 @@ Create your configuration file:
 ```
 
 `split_report`: whether to post each scrum entry as a separate message or post all scrum entries in the same message.
-
-Run the bot with a slack bot user token
-
-```sh
-SCRUMPOLICE_SLACK_TOKEN=xoxb-mytoken scrumpolice -config config.json
-```
 
 # Development
 

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -88,10 +88,13 @@ func (b *Bot) handleMessage(event *slack.MessageEvent) {
 		return
 	}
 
+	if !b.HandleTeamEditionMessage(event) {
+		return
+	}
+
 	// HANDLE GLOBAL PUBLIC COMMANDS HERE
 	if strings.Contains(eventText, ":wave:") {
 		b.reactToEvent(event, "wave")
-		b.reactToEvent(event, "oncoming_police_car")
 		return
 	}
 
@@ -136,7 +139,7 @@ func (b *Bot) handleMessage(event *slack.MessageEvent) {
 		return
 	}
 
-	if eventText == "i'm back" || eventText == "i am back" {
+	if eventText == "i'm back" || eventText == "i am back" || eventText == "i’m back" {
 		b.backInOffice(event)
 		return
 	}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -204,7 +204,8 @@ func (b *Bot) help(event *slack.MessageEvent) {
 			"- `restart scrum`: restart your last done scrum, if it wasn't posted\n" +
 			"- `out of office`: mark current user as out of office (until `i'm back` is used)\n" +
 			"- `[user] is out of office`: mark the specified user as out of office (until he or she uses `i'm back`)\n" +
-			"- `i am back` or `i'm back`: mark current user as in office. MacOS smart quote can screw up with the `i'm back` command.",
+			"- `i am back` or `i'm back`: mark current user as in office. MacOS smart quote can screw up with the `i'm back` command\n" +
+			"-  edit team`: make changes to a team you are part of.",
 	}
 
 	params := slack.PostMessageParameters{AsUser: true}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -320,7 +320,7 @@ func (b *Bot) canQuitBotContextHandlerFunc(handler func(event *slack.MessageEven
 func (b *Bot) canQuitBotContext(handler BotContextHandler) BotContextHandler {
 	return BotContextHandlerFunc(func(event *slack.MessageEvent) bool {
 		if event.Text == "quit" {
-			b.slackBotAPI.PostMessage(event.Channel, "Action is canceled, if you wanna do anything else, just poke me, `help` is always available! :wave:", slack.PostMessageParameters{AsUser: true})
+			b.slackBotAPI.PostMessage(event.Channel, "Alright! If you wanna do anything else, just :poke: me, `help` is always available! :wave:", slack.PostMessageParameters{AsUser: true})
 			delete(b.userContexts, event.User)
 			return false
 		}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -205,7 +205,9 @@ func (b *Bot) help(event *slack.MessageEvent) {
 			"- `out of office`: mark current user as out of office (until `i'm back` is used)\n" +
 			"- `[user] is out of office`: mark the specified user as out of office (until he or she uses `i'm back`)\n" +
 			"- `i am back` or `i'm back`: mark current user as in office. MacOS smart quote can screw up with the `i'm back` command\n" +
-			"-  edit team`: make changes to a team you are part of.",
+			"- `add team`: create a new team with a basic configuration.\n" +
+			"- `remove team`: Delete the configuration of one of your teams. The team won't receive any more notifications :disappointed:\n" +
+			"- `edit team`: make changes to a team you are part of.",
 	}
 
 	params := slack.PostMessageParameters{AsUser: true}

--- a/bot/teambotmodule.go
+++ b/bot/teambotmodule.go
@@ -130,15 +130,16 @@ func (b *Bot) chooseTeamName(event *slack.MessageEvent) bool {
 		}
 
 		members := []string{author.Name}
-		var firstReminderBefore time.Duration = -8 * time.Second
-		var lastReminderBefore time.Duration = -8 * time.Second
-		schedule, _ := cron.Parse("@every 30s")
+		defaultCron := "0 5 9 * * MON,WED,FRI"
+		var firstReminderBefore time.Duration = -50 * time.Minute
+		var lastReminderBefore time.Duration = -5 * time.Minute
+		schedule, _ := cron.Parse(defaultCron)
 
 		questions := []*scrum.QuestionSet{&scrum.QuestionSet{
 			Questions: []string{"What did you do yesterday?", "What will you do today?", "Are you being blocked by someone for a review? who? why?"},
 			FirstReminderBeforeReport: firstReminderBefore,
 			LastReminderBeforeReport: lastReminderBefore,
-			ReportScheduleCron: "@every 30s",
+			ReportScheduleCron: defaultCron,
 			ReportSchedule: schedule,
 		}}
 

--- a/bot/teambotmodule.go
+++ b/bot/teambotmodule.go
@@ -180,7 +180,7 @@ func (b *Bot) chooseTeamToEdit(event *slack.MessageEvent, cb ChosenTeamFunc) boo
 
 	teams := b.scrum.GetTeamsForUser(user.Name)
 	if len(teams) == 0 {
-		b.slackBotAPI.PostMessage(event.Channel, "There is no teams, use 'create team' to create a new team", slack.PostMessageParameters{AsUser: true})
+		b.slackBotAPI.PostMessage(event.Channel, "There is no teams, use 'add team' to create a new team", slack.PostMessageParameters{AsUser: true})
 		return false
 	}
 

--- a/bot/teambotmodule.go
+++ b/bot/teambotmodule.go
@@ -1,0 +1,167 @@
+package bot
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/nlopes/slack"
+	log "github.com/sirupsen/logrus"
+)
+
+// HandleMessage handle a received message for team and returns if the bot shall continue to process the message or stop
+// continue = true
+// stop = false
+func (b *Bot) HandleTeamEditionMessage(event *slack.MessageEvent) bool {
+	// "edit team [name]"
+	// [name == name of the team]
+	// editing team [name]. if you want to abort say stop scrum
+
+	if context, ok := b.userContexts[event.User]; ok {
+		return context.HandleMessage(event)
+	}
+
+	if strings.HasPrefix(strings.ToLower(event.Text), "edit team") {
+		return b.startTeamEdition(event)
+	}
+
+	return true
+}
+
+func (b *Bot) cancelTeamEdition(event *slack.MessageEvent) bool {
+	_, err := b.slackBotAPI.GetUserInfo(event.User)
+	if err != nil {
+		b.logSlackRelatedError(event, err, "Fail to get user information.")
+		return false
+	}
+
+	b.slackBotAPI.PostMessage(event.Channel, "Team edition was cancelled. Better luck next time!", slack.PostMessageParameters{AsUser: true})
+	return false
+}
+
+func (b *Bot) startTeamEdition(event *slack.MessageEvent) bool {
+	_, err := b.slackBotAPI.GetUserInfo(event.User)
+	if err != nil {
+		b.logSlackRelatedError(event, err, "Fail to get user information.")
+		b.slackBotAPI.PostMessage(event.Channel, "There was an error editing the team, please try again", slack.PostMessageParameters{AsUser: true})
+		return false
+	}
+
+	teams := b.scrum.GetTeams()
+	if len(teams) == 0 {
+		b.slackBotAPI.PostMessage(event.Channel, "There is no teams, use 'create team' to create a new team", slack.PostMessageParameters{AsUser: true})
+	}
+
+	return b.chooseTeamToEdit(event, teams)
+}
+
+func (b *Bot) chooseTeamToEdit(event *slack.MessageEvent, teams []string) bool {
+	choices := make([]string, len(teams))
+	sort.Strings(teams)
+	for i, team := range teams {
+		choices[i] = fmt.Sprintf("%d - %s", i, team)
+	}
+
+	msg := fmt.Sprintf("Choose a team :\n%s", strings.Join(choices, "\n"))
+	b.slackBotAPI.PostMessage(event.Channel, msg, slack.PostMessageParameters{AsUser: true})
+
+	b.setUserContext(event.User, b.canQuitBotContextHandlerFunc(func(event *slack.MessageEvent) bool {
+		i, err := strconv.Atoi(event.Text)
+
+		if i < 0 || i >= len(teams) || err != nil {
+			b.slackBotAPI.PostMessage(event.Channel, "Wrong choices, please try again :p or type `quit`", slack.PostMessageParameters{AsUser: true})
+			b.chooseTeamToEdit(event, teams)
+			return false
+		}
+
+		return b.choosenTeamToEdit(event, teams[i])
+	}))
+
+	return false
+}
+
+func (b *Bot) choosenTeamToEdit(event *slack.MessageEvent, team string) bool {
+	message := slack.Attachment{
+		MarkdownIn: []string{"text"},
+		Text: "" +
+			"- `add @name`: Add *@name* to team\n" +
+			"- `remove @name`: Remove *@name* from team",
+	}
+
+	params := slack.PostMessageParameters{AsUser: true}
+	params.Attachments = []slack.Attachment{message}
+
+	_, _, err := b.slackBotAPI.PostMessage(event.Channel, "What do you want to do with team"+team, params)
+	if err != nil {
+		b.logSlackRelatedError(event, err, "Fail to post message to slack.")
+		return false
+	}
+
+	b.setUserContext(event.User, b.canQuitBotContextHandlerFunc(func(event *slack.MessageEvent) bool {
+		params := getParams(`(?i)(?P<action>add|remove) <@(?P<user>.+)>\s*`, event.Text)
+		fmt.Println(params)
+
+		if len(params) == 0 || params["action"] == "" || params["user"] == "" {
+			b.slackBotAPI.PostMessage(event.Channel, "Wrong choices, please try again :p or type `quit`", slack.PostMessageParameters{AsUser: true})
+			b.choosenTeamToEdit(event, team)
+			return false
+		}
+		userId := params["user"]
+		b.logSlackRelatedError(event, err, "Fail to get user information. user:"+userId)
+
+		user, err := b.slackBotAPI.GetUserInfo(userId)
+		if err != nil {
+			b.logSlackRelatedError(event, err, "Fail to get user information.")
+			b.slackBotAPI.PostMessage(event.Channel, "Hmmmm, I couldn't find the user. Try again!", slack.PostMessageParameters{AsUser: true})
+			b.choosenTeamToEdit(event, team)
+			return false
+		}
+		username := user.Name
+
+		return b.chooseTeamAction(event, team, params["action"], username)
+	}))
+
+	return false
+}
+
+func (b *Bot) chooseTeamAction(event *slack.MessageEvent, team string, action string, username string) bool {
+	if action == "add" {
+		b.scrum.AddToTeam(team, username)
+
+		b.slackBotAPI.PostMessage(event.Channel, "I've added @"+username+" to team "+team, slack.PostMessageParameters{AsUser: true})
+
+		author, err := b.slackBotAPI.GetUserInfo(event.User)
+		if err != nil {
+			b.logSlackRelatedError(event, err, "Fail to get user information.")
+			return false
+		}
+
+		b.slackBotAPI.PostMessage("@"+username, "You've been added in team "+team+" by @"+author.Name+".", slack.PostMessageParameters{AsUser: true})
+		log.WithFields(log.Fields{
+			"user":   username,
+			"team":   team,
+			"doneBy": author.Name,
+		}).Info("User was added to team.")
+	} else if action == "remove" {
+		b.scrum.RemoveFromTeam(team, username)
+
+		b.slackBotAPI.PostMessage(event.Channel, "I've removed @"+username+" to team "+team, slack.PostMessageParameters{AsUser: true})
+
+		author, err := b.slackBotAPI.GetUserInfo(event.User)
+		if err != nil {
+			b.logSlackRelatedError(event, err, "Fail to get user information.")
+			return false
+		}
+
+		b.slackBotAPI.PostMessage("@"+username, "You've been removed from team "+team+" by @"+author.Name+".", slack.PostMessageParameters{AsUser: true})
+		log.WithFields(log.Fields{
+			"user":   username,
+			"team":   team,
+			"doneBy": author.Name,
+		}).Info("User was removed from team.")
+	}
+
+	b.unsetUserContext(event.User)
+	return false
+}

--- a/bot/teambotmodule.go
+++ b/bot/teambotmodule.go
@@ -235,7 +235,7 @@ func (b *Bot) choosenTeamToEdit(event *slack.MessageEvent, team string) bool {
 	}
 
 	b.setUserContext(event.User, b.canQuitBotContextHandlerFunc(func(event *slack.MessageEvent) bool {
-		params := getParams(`(?i)(?P<action>add|remove|edit) <?(?P<entity>.+)>?\s*`, event.Text)
+		params := getParams(`(?i)(?P<action>add|remove|edit) <?(?P<entity>.+[^>])>?\s*`, event.Text)
 		fmt.Println(params)
 
 		if len(params) == 0 || params["action"] == "" || params["entity"] == "" {
@@ -317,6 +317,8 @@ func (b *Bot) changeTeamChannel(event *slack.MessageEvent, team string) bool {
 		}).Info("Changed team channel.")
 
 		b.unsetUserContext(event.User)
+		b.choosenTeamToEdit(event, team)
+
 		return false
 	}))
 
@@ -364,6 +366,8 @@ func (b *Bot) changeScrumQuestion(event *slack.MessageEvent, team string, questi
 			b.printTeamQuestions(event, team)
 
 			b.unsetUserContext(event.User)
+			b.choosenTeamToEdit(event, team)
+
 			return false
 		}
 
@@ -402,6 +406,7 @@ func (b *Bot) ChangeUserAction(event *slack.MessageEvent, team string, action st
 			"team":   team,
 			"doneBy": author.Name,
 		}).Info("User was added to team.")
+
 	} else if action == "remove" {
 		users := b.scrum.GetUsersForTeam(team)
 		isInTeam := false
@@ -435,6 +440,8 @@ func (b *Bot) ChangeUserAction(event *slack.MessageEvent, team string, action st
 	}
 
 	b.unsetUserContext(event.User)
+	b.choosenTeamToEdit(event, team)
+
 	return false
 }
 
@@ -477,6 +484,9 @@ func (b *Bot) changeScrumSchedule(event *slack.MessageEvent, team string) bool {
 		msg = "Schedule successfully changed!"
 		b.slackBotAPI.PostMessage(event.Channel, msg, slack.PostMessageParameters{AsUser: true})
 		b.unsetUserContext(event.User)
+
+		b.choosenTeamToEdit(event, team)
+
 		return false
 	}))
 	return false
@@ -512,6 +522,8 @@ func (b *Bot) changeFirstReminder(event *slack.MessageEvent, team string) bool {
 		msg = "First reminder duration successfully changed! The users will be warned " + strings.Replace(duration.String(), "-", "", -1) + " before the scrum."
 		b.slackBotAPI.PostMessage(event.Channel, msg, slack.PostMessageParameters{AsUser: true})
 		b.unsetUserContext(event.User)
+		b.choosenTeamToEdit(event, team)
+
 		return false
 	}))
 	return false
@@ -547,6 +559,8 @@ func (b *Bot) changeSecondReminder(event *slack.MessageEvent, team string) bool 
 		msg = "Last reminder duration successfully changed! The users will be warned " + strings.Replace(duration.String(), "-", "", -1) + " before the scrum."
 		b.slackBotAPI.PostMessage(event.Channel, msg, slack.PostMessageParameters{AsUser: true})
 		b.unsetUserContext(event.User)
+		b.choosenTeamToEdit(event, team)
+
 		return false
 	}))
 	return false

--- a/bot/utils.go
+++ b/bot/utils.go
@@ -1,0 +1,17 @@
+package bot
+
+import "regexp"
+
+func getParams(regEx, url string) (paramsMap map[string]string) {
+
+	var compRegEx = regexp.MustCompile(regEx)
+	match := compRegEx.FindStringSubmatch(url)
+
+	paramsMap = make(map[string]string)
+	for i, name := range compRegEx.SubexpNames() {
+		if i > 0 && i <= len(match) {
+			paramsMap[name] = match[i]
+		}
+	}
+	return
+}

--- a/scrum/config.go
+++ b/scrum/config.go
@@ -36,10 +36,6 @@ import (
 //   ]
 // }
 type (
-	ConfigurationProvider interface {
-		Config() *Config
-		OnChange(handler func(cfg *Config))
-	}
 
 	// Config is the configuration format
 	Config struct {

--- a/scrum/config.go
+++ b/scrum/config.go
@@ -1,12 +1,8 @@
 package scrum
 
 import (
-	"encoding/json"
 	"log"
-	"os"
 	"time"
-
-	"github.com/fsnotify/fsnotify"
 	"github.com/robfig/cron"
 )
 
@@ -56,6 +52,7 @@ type (
 		Channel      string              `json:"channel"`
 		Members      []string            `json:"members"`
 		QuestionSets []QuestionSetConfig `json:"question_sets"`
+		OutOfOffice  []string            `json:"out_of_office"`
 		Timezone     string              `json:"timezone"`
 		SplitReport  bool                `json:"split_report"`
 	}
@@ -67,66 +64,6 @@ type (
 		LastReminderBeforeReport  string   `json:"last_reminder_limit"`
 	}
 )
-
-type configFileWatcher struct {
-	config         *Config
-	changeHandlers []func(cfg *Config)
-}
-
-func NewConfigWatcher(file string) ConfigurationProvider {
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fw := &configFileWatcher{changeHandlers: []func(cfg *Config){}}
-	go func() {
-		defer watcher.Close()
-		for {
-			select {
-			case event := <-watcher.Events:
-				if event.Op&fsnotify.Write == fsnotify.Write {
-					log.Println("Configuration file modified '", event.Name, "', reloading...")
-					fw.reloadAndDistributeChange(file)
-				}
-			case err := <-watcher.Errors:
-				log.Println("Error while watching for configuration file:", err)
-			}
-		}
-	}()
-
-	err = watcher.Add(file)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Println("Loading initial configuration")
-	fw.reloadAndDistributeChange(file)
-	return fw
-}
-
-func (fw *configFileWatcher) Config() *Config {
-	return fw.config
-}
-
-func (fw *configFileWatcher) OnChange(handler func(cfg *Config)) {
-	fw.changeHandlers = append(fw.changeHandlers, handler)
-}
-
-func (fw *configFileWatcher) reloadAndDistributeChange(filename string) {
-	file, err := os.Open(filename)
-	if err != nil {
-		log.Println("Cannot open file '", filename, "', error:", err)
-	}
-	err = json.NewDecoder(file).Decode(&fw.config)
-	if err != nil {
-		log.Println("Cannot parse configuration file ('", filename, "') content:", err)
-	}
-
-	for _, handler := range fw.changeHandlers {
-		go handler(fw.config)
-	}
-}
 
 func (c *Config) ToTeams() []*Team {
 	teams := []*Team{}
@@ -186,6 +123,7 @@ func (qs *QuestionSetConfig) toQuestionSet() (*QuestionSet, error) {
 	return &QuestionSet{
 		Questions:                 qs.Questions,
 		ReportSchedule:            schedule,
+		ReportScheduleCron:        qs.ReportScheduleCron,
 		FirstReminderBeforeReport: fir,
 		LastReminderBeforeReport:  sec,
 	}, nil

--- a/scrum/configstorage.go
+++ b/scrum/configstorage.go
@@ -1,6 +1,6 @@
 package scrum
 
 type ConfigurationStorage interface {
-	load() *Config
-	save(config *Config)
+	Load() *Config
+	Save(config *Config)
 }

--- a/scrum/configstorage.go
+++ b/scrum/configstorage.go
@@ -1,0 +1,6 @@
+package scrum
+
+type ConfigurationStorage interface {
+	load() *Config
+	save(config *Config)
+}

--- a/scrum/fileconfigstorage.go
+++ b/scrum/fileconfigstorage.go
@@ -1,0 +1,45 @@
+package scrum
+
+import (
+	"os"
+	"log"
+	"encoding/json"
+)
+
+type FileConfigurationStorage struct {
+	fileName *string
+}
+
+func (configStorage *FileConfigurationStorage) load() *Config {
+	file, err := os.Open(*configStorage.fileName)
+	if err != nil {
+		log.Println("Cannot open file '", *configStorage.fileName, "', error:", err)
+		return nil
+	}
+
+	var config Config
+
+	err = json.NewDecoder(file).Decode(&config)
+	if err != nil {
+		log.Println("Cannot parse configuration file ('", *configStorage.fileName, "') content:", err)
+	}
+	return &config
+	}
+
+func (configStorage *FileConfigurationStorage) save(config *Config) {
+	file, err := os.OpenFile(*configStorage.fileName, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		log.Println("Cannot open file '", *configStorage.fileName, "', error:", err)
+		return
+	}
+
+	err = json.NewEncoder(file).Encode(&config)
+	if err != nil {
+		log.Println("Cannot serialize configuration file ('", *configStorage.fileName, "') content:", err)
+	}
+}
+
+func NewFileConfigurationStorage(fileName *string) ConfigurationStorage {
+
+	return &FileConfigurationStorage{fileName}
+}

--- a/scrum/fileconfigstorage.go
+++ b/scrum/fileconfigstorage.go
@@ -10,7 +10,7 @@ type FileConfigurationStorage struct {
 	fileName *string
 }
 
-func (configStorage *FileConfigurationStorage) load() *Config {
+func (configStorage *FileConfigurationStorage) Load() *Config {
 	file, err := os.Open(*configStorage.fileName)
 	if err != nil {
 		log.Println("Cannot open file '", *configStorage.fileName, "', error:", err)
@@ -26,7 +26,7 @@ func (configStorage *FileConfigurationStorage) load() *Config {
 	return &config
 	}
 
-func (configStorage *FileConfigurationStorage) save(config *Config) {
+func (configStorage *FileConfigurationStorage) Save(config *Config) {
 	file, err := os.OpenFile(*configStorage.fileName, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		log.Println("Cannot open file '", *configStorage.fileName, "', error:", err)

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -28,6 +28,7 @@ type Service interface {
 	DeleteTeam(team string)
 	AddToTeam(team string, username string)
 	RemoveFromTeam(team string, username string)
+	ChangeTeamChannel(team string, channel string)
 }
 
 type service struct {
@@ -497,6 +498,12 @@ func (m *service) AddTeam(team *Team) {
 
 func (m *service) DeleteTeam(team string) {
 	delete(m.teamStates, team)
+
+	m.saveConfig()
+}
+
+func (m *service) ChangeTeamChannel(team string, channel string) {
+	m.teamStates[team].Channel = channel
 
 	m.saveConfig()
 }

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -491,13 +491,7 @@ func (m *service) AddTeam(team *Team) {
 }
 
 func (m *service) DeleteTeam(team string) {
-	var teams map[string]*TeamState
-	for _, t := range m.teamStates {
-		if t.Name != team {
-			teams[t.Name] = t
-		}
-	}
-	m.teamStates = teams
+	delete(m.teamStates, team)
 
 	m.saveConfig()
 }

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -23,6 +23,8 @@ type Service interface {
 	SaveReport(report *Report, qs *QuestionSet)
 	AddToOutOfOffice(team string, username string)
 	RemoveFromOutOfOffice(team string, username string)
+	AddTeam(team *Team)
+	DeleteTeam(team string)
 	AddToTeam(team string, username string)
 	RemoveFromTeam(team string, username string)
 }
@@ -476,6 +478,26 @@ func (m *service) RemoveFromTeam(team string, username string) {
 		}
 	}
 	m.teamStates[team].Members = members
+
+	m.saveConfig()
+}
+
+func (m *service) AddTeam(team *Team) {
+	location, _ := time.LoadLocation(m.getCurrentConfig().Timezone)
+	state := initTeamState(team, location, m)
+	m.teamStates[team.Name] = state
+
+	m.saveConfig()
+}
+
+func (m *service) DeleteTeam(team string) {
+	var teams map[string]*TeamState
+	for _, t := range m.teamStates {
+		if t.Name != team {
+			teams[t.Name] = t
+		}
+	}
+	m.teamStates = teams
 
 	m.saveConfig()
 }

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -20,6 +20,7 @@ type Service interface {
 	GetTeamByName(teamName string) (*TeamState, error)
 	GetTeamsForUser(username string) []string
 	GetQuestionSetsForTeam(team string) []*QuestionSet
+	GetUsersForTeam(team string) []string
 	SaveReport(report *Report, qs *QuestionSet)
 	AddToOutOfOffice(team string, username string)
 	RemoveFromOutOfOffice(team string, username string)
@@ -409,6 +410,10 @@ func (m *service) GetTeamByName(teamName string) (*TeamState, error) {
 
 func (m *service) GetQuestionSetsForTeam(team string) []*QuestionSet {
 	return m.teamStates[team].QuestionsSets
+}
+
+func (m *service) GetUsersForTeam(team string) []string {
+	return m.teamStates[team].Members
 }
 
 func (m *service) SaveReport(report *Report, qs *QuestionSet) {

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -263,10 +263,7 @@ func NewService(configurationStorage ConfigurationStorage, slackBotAPI *slack.Cl
 	}
 
 	// initial *refresh
-	mod.refresh(configurationStorage.load())
-
-	var fileName = "test.json"
-	NewFileConfigurationStorage(&fileName).save(mod.getCurrentConfig())
+	mod.refresh(configurationStorage.Load())
 
 	return mod
 }
@@ -305,6 +302,10 @@ func (mod *service) refresh(config *Config) {
 		state = initTeamState(team, globalLocation, mod)
 		mod.teamStates[team.Name] = state
 	}
+}
+
+func(mod *service) saveConfig(){
+	mod.configurationStorage.Save(mod.getCurrentConfig())
 }
 
 func (mod *service) getCurrentConfig() *Config {

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -31,6 +31,7 @@ type Service interface {
 	ReplaceScrumScheduleInTeam(team string, schedule cron.Schedule, scheduleAsString string)
 	ReplaceFirstReminderInTeam(team string, duration time.Duration)
 	ReplaceSecondReminderInTeam(team string, duration time.Duration)
+	ReplaceScrumQuestionsInTeam(team string, questions []string)
 	ChangeTeamChannel(team string, channel string)
 }
 
@@ -531,6 +532,15 @@ func (m *service) ReplaceSecondReminderInTeam(team string, duration time.Duratio
 	m.teamStates[team].Team.QuestionsSets[0].LastReminderBeforeReport = duration
 
 	m.teamStates[team].Cron.Stop()
+	initTeamstate(m.teamStates[team].Team, m.teamStates[team])
+
+	m.saveConfig()
+}
+
+func (m *service) ReplaceScrumQuestionsInTeam(team string, questions []string)  {
+	m.teamStates[team].Cron.Stop()
+
+	m.teamStates[team].Team.QuestionsSets[0].Questions = questions
 	initTeamstate(m.teamStates[team].Team, m.teamStates[team])
 
 	m.saveConfig()

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -504,6 +504,7 @@ func (m *service) AddTeam(team *Team) {
 }
 
 func (m *service) DeleteTeam(team string) {
+	m.teamStates[team].Cron.Stop()
 	delete(m.teamStates, team)
 
 	m.saveConfig()

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -29,6 +29,8 @@ type Service interface {
 	AddToTeam(team string, username string)
 	RemoveFromTeam(team string, username string)
 	ReplaceScrumScheduleInTeam(team string, schedule cron.Schedule, scheduleAsString string)
+	ReplaceFirstReminderInTeam(team string, duration time.Duration)
+	ReplaceSecondReminderInTeam(team string, duration time.Duration)
 	ChangeTeamChannel(team string, channel string)
 }
 
@@ -509,6 +511,24 @@ func (m *service) DeleteTeam(team string) {
 func (m *service) ReplaceScrumScheduleInTeam(team string, schedule cron.Schedule, scheduleAsString string)  {
 	m.teamStates[team].Team.QuestionsSets[0].ReportSchedule = schedule
 	m.teamStates[team].Team.QuestionsSets[0].ReportScheduleCron = scheduleAsString
+
+	m.teamStates[team].Cron.Stop()
+	initTeamstate(m.teamStates[team].Team, m.teamStates[team])
+
+	m.saveConfig()
+}
+
+func (m *service) ReplaceFirstReminderInTeam(team string, duration time.Duration)  {
+	m.teamStates[team].Team.QuestionsSets[0].FirstReminderBeforeReport = duration
+
+	m.teamStates[team].Cron.Stop()
+	initTeamstate(m.teamStates[team].Team, m.teamStates[team])
+
+	m.saveConfig()
+}
+
+func (m *service) ReplaceSecondReminderInTeam(team string, duration time.Duration)  {
+	m.teamStates[team].Team.QuestionsSets[0].LastReminderBeforeReport = duration
 
 	m.teamStates[team].Cron.Stop()
 	initTeamstate(m.teamStates[team].Team, m.teamStates[team])

--- a/scrum/state.go
+++ b/scrum/state.go
@@ -2,7 +2,6 @@ package scrum
 
 import (
 	"time"
-
 	"github.com/robfig/cron"
 )
 
@@ -20,7 +19,35 @@ type (
 	QuestionSet struct {
 		Questions                 []string
 		ReportSchedule            cron.Schedule
+		ReportScheduleCron        string
 		FirstReminderBeforeReport time.Duration
 		LastReminderBeforeReport  time.Duration
 	}
 )
+
+func (team *Team) toTeamConfig() *TeamConfig {
+	var questionSetConfigs []QuestionSetConfig
+	for _, questionSet := range team.QuestionsSets {
+		questionSetConfig := questionSet.toQuestionSetConfig()
+		questionSetConfigs = append(questionSetConfigs, *questionSetConfig)
+	}
+
+	return &TeamConfig{
+		Name:         team.Name,
+		Channel:      team.Channel,
+		Members:      team.Members,
+		QuestionSets: questionSetConfigs,
+		Timezone:     team.Timezone.String(),
+		OutOfOffice:  team.OutOfOffice,
+		SplitReport:  team.SplitReport,
+	}
+}
+
+func (questionSet *QuestionSet) toQuestionSetConfig() *QuestionSetConfig {
+	return &QuestionSetConfig{
+		Questions:                 questionSet.Questions,
+		ReportScheduleCron:        questionSet.ReportScheduleCron,
+		FirstReminderBeforeReport: questionSet.FirstReminderBeforeReport.String(),
+		LastReminderBeforeReport:  questionSet.FirstReminderBeforeReport.String(),
+	}
+}

--- a/scrumpolice.go
+++ b/scrumpolice.go
@@ -32,25 +32,23 @@ func main() {
 		log.Fatalln("slack bot token must be set in SCRUMPOLICE_SLACK_TOKEN")
 	}
 
-
 	logger := logrus.New()
 
-	permanentConfigFile := "db.json"
-	flag.StringVar(&permanentConfigFile, "databaseFile", permanentConfigFile, "The permanent database file")
-	flag.Parse()
-	configFile := "config.json"
-	flag.StringVar(&configFile, "config", configFile, "The configuration file")
+	var databaseFile string
+	var configFile string
+	flag.StringVar(&databaseFile, "databaseFile", "db.json", "The permanent database file")
+	flag.StringVar(&configFile, "config", "config.json", "The configuration file")
 	flag.Parse()
 
 	slackAPIClient := slack.New(slackBotToken)
-	scrumService := scrum.NewService(initConfig(configFile, permanentConfigFile), slackAPIClient)
+	scrumService := scrum.NewService(initConfig(configFile, databaseFile), slackAPIClient)
 
 	// Create and run bot
 	b := bot.New(slackAPIClient, logger, scrumService)
 	b.Run()
 }
 
-func initConfig(configFileName string, permanentDbFileName string) scrum.ConfigurationStorage  {
+func initConfig(configFileName string, permanentDbFileName string) scrum.ConfigurationStorage {
 	var configStorage = scrum.NewFileConfigurationStorage(&permanentDbFileName)
 
 	if _, err := os.Stat(permanentDbFileName); os.IsNotExist(err) {
@@ -58,7 +56,7 @@ func initConfig(configFileName string, permanentDbFileName string) scrum.Configu
 		configStorage.Save(scrum.NewFileConfigurationStorage(&configFileName).Load())
 	}
 	if configStorage.Load() == nil {
-		log.Fatal("Could not load proper configuration. Will not boot.")
+		log.Fatalln("Could not load proper configuration. Will not boot.")
 	}
 	return configStorage
 }

--- a/scrumpolice.go
+++ b/scrumpolice.go
@@ -38,9 +38,10 @@ func main() {
 
 	// Injection
 	logger := logrus.New()
-	configurationProvider := scrum.NewConfigWatcher(configFile)
+	// TODO copy config before if necessary
+	configStorage := scrum.NewFileConfigurationStorage(&configFile)
 	slackAPIClient := slack.New(slackBotToken)
-	scrum := scrum.NewService(configurationProvider, slackAPIClient)
+	scrum := scrum.NewService(configStorage, slackAPIClient)
 
 	// Create and run bot
 	b := bot.New(slackAPIClient, logger, scrum)


### PR DESCRIPTION
The bot can now edit its own configuration. The users can use the "add team", "remove team" and "edit team" to change the config. The changes are saved to a file specified by a new command line parameter ("databaseFile"). It is distinct from the already existing config file. If the specified config file (or default one) is not present, the bot will attempt to load the config from the old file to the new persistent one.