### PR TITLE
Handle timezones better

### DIFF
--- a/scrum/config.go
+++ b/scrum/config.go
@@ -64,12 +64,12 @@ type (
 func (c *Config) ToTeams() []*Team {
 	teams := []*Team{}
 	for _, teamConfig := range c.Teams {
-		teams = append(teams, teamConfig.ToTeam())
+		teams = append(teams, teamConfig.ToTeam(c.Timezone))
 	}
 	return teams
 }
 
-func (tc *TeamConfig) ToTeam() *Team {
+func (tc *TeamConfig) ToTeam(timezone string) *Team {
 	qsets := []*QuestionSet{}
 	for _, questionsetconfig := range tc.QuestionSets {
 		qs, err := questionsetconfig.toQuestionSet()
@@ -88,14 +88,17 @@ func (tc *TeamConfig) ToTeam() *Team {
 		SplitReport:   tc.SplitReport,
 	}
 
+	tz := timezone
 	if tc.Timezone != "" {
-		lloc, err := time.LoadLocation(tc.Timezone)
+		tz = tc.Timezone
+	}
+
+	lloc, err := time.LoadLocation(tz)
 		if err != nil {
 			log.Println("Timezone error for team:", tc.Name, "Will use default timezone")
 			lloc = nil
 		}
 		t.Timezone = lloc
-	}
 
 	return t
 }

--- a/scrum/config.go
+++ b/scrum/config.go
@@ -88,17 +88,16 @@ func (tc *TeamConfig) ToTeam(timezone string) *Team {
 		SplitReport:   tc.SplitReport,
 	}
 
-	tz := timezone
 	if tc.Timezone != "" {
-		tz = tc.Timezone
+		timezone = tc.Timezone
 	}
 
-	lloc, err := time.LoadLocation(tz)
-		if err != nil {
-			log.Println("Timezone error for team:", tc.Name, "Will use default timezone")
-			lloc = nil
-		}
-		t.Timezone = lloc
+	lloc, err := time.LoadLocation(timezone)
+	if err != nil {
+		log.Println("Timezone error for team:", tc.Name, "Will use default timezone")
+		lloc = nil
+	}
+	t.Timezone = lloc
 
 	return t
 }

--- a/scrum/service.go
+++ b/scrum/service.go
@@ -339,11 +339,7 @@ func initTeamState(team *Team, globalLocation *time.Location, mod *service) *Tea
 		questionSetStates: map[*QuestionSet]*questionSetState{},
 	}
 
-	loc := globalLocation
-	if team.Timezone != nil {
-		loc = team.Timezone
-	}
-	state.Cron = cron.NewWithLocation(loc)
+	state.Cron = cron.NewWithLocation(team.Timezone)
 
 	initTeamstate(team, state)
 
@@ -497,6 +493,7 @@ func (m *service) RemoveFromTeam(team string, username string) {
 
 func (m *service) AddTeam(team *Team) {
 	location, _ := time.LoadLocation(m.getCurrentConfig().Timezone)
+	team.Timezone = location
 	state := initTeamState(team, location, m)
 	m.teamStates[team.Name] = state
 


### PR DESCRIPTION
* Set default timezone when deserializing because null timezone is equivalent to UTC.

Currently there is no way to set timezones from the bot but should we add the possibility this could be used to override the default value that will be added on team creation and when the config has an empty timezone string.