### PR TITLE
Should only answer in private channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ before_script:
 services:
   - docker
 
-script: 
+script:
   - go get -t -v ./...
   - go test -v ./...
   - sh ./build.sh
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
     docker build -t coveo/scrumpolice .;
     docker tag coveo/scrumpolice coveo/scrumpolice:latest;

--- a/bot/scrumbotmodule.go
+++ b/bot/scrumbotmodule.go
@@ -21,6 +21,7 @@ func (b *Bot) HandleScrumMessage(event *slack.MessageEvent) bool {
 	// starting scrum for team [team] date [date]. if you want to abort say stop scrum
 
 	// this module only takes case in private messages
+	// D stands for direct message
 	if event.Channel[0] != 'D' {
 		return true
 	}

--- a/bot/teambotmodule.go
+++ b/bot/teambotmodule.go
@@ -23,6 +23,7 @@ func (b *Bot) HandleTeamEditionMessage(event *slack.MessageEvent) bool {
 	// editing team [name]. if you want to abort say stop scrum
 
 	// this module only takes case in private messages
+	// D stands for direct message
 	if event.Channel[0] != 'D' {
 		return true
 	}

--- a/bot/teambotmodule.go
+++ b/bot/teambotmodule.go
@@ -22,6 +22,11 @@ func (b *Bot) HandleTeamEditionMessage(event *slack.MessageEvent) bool {
 	// [name == name of the team]
 	// editing team [name]. if you want to abort say stop scrum
 
+	// this module only takes case in private messages
+	if event.Channel[0] != 'D' {
+		return true
+	}
+
 	if context, ok := b.userContexts[event.User]; ok {
 		return context.HandleMessage(event)
 	}
@@ -135,7 +140,7 @@ func (b *Bot) chooseTeamName(event *slack.MessageEvent) bool {
 		var lastReminderBefore time.Duration = -5 * time.Minute
 		schedule, _ := cron.Parse(defaultCron)
 
-		questions := []*scrum.QuestionSet{&scrum.QuestionSet{
+		questions := []*scrum.QuestionSet{{
 			Questions:                 []string{"What did you do yesterday?", "What will you do today?", "Are you being blocked by someone for a review? who? why?"},
 			FirstReminderBeforeReport: firstReminderBefore,
 			LastReminderBeforeReport:  lastReminderBefore,


### PR DESCRIPTION
Currently, if you start a scrum, then you talk in an other channel, the scrumpolice will answer
The scrumpolice should only answer in his own channel